### PR TITLE
@next/font migrated to buil-in-next-font

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -8,7 +8,6 @@
       "name": "netflix-clone",
       "version": "0.1.0",
       "dependencies": {
-        "@next/font": "^13.3.1",
         "@types/node": "18.15.11",
         "@types/react": "18.0.37",
         "@types/react-dom": "18.0.11",
@@ -357,11 +356,6 @@
       "dependencies": {
         "glob": "7.1.7"
       }
-    },
-    "node_modules/@next/font": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.3.1.tgz",
-      "integrity": "sha512-S8Shizt4xlHDItXTAowEoyktiaLIEzTxJeXPaRu+VDeb21yXu7kMX2DUQE5Un+kb/ViCaAdWlyltCuS2sywEjA=="
     },
     "node_modules/@next/swc-darwin-arm64": {
       "version": "13.3.0",
@@ -6004,11 +5998,6 @@
       "requires": {
         "glob": "7.1.7"
       }
-    },
-    "@next/font": {
-      "version": "13.3.1",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-13.3.1.tgz",
-      "integrity": "sha512-S8Shizt4xlHDItXTAowEoyktiaLIEzTxJeXPaRu+VDeb21yXu7kMX2DUQE5Un+kb/ViCaAdWlyltCuS2sywEjA=="
     },
     "@next/swc-darwin-arm64": {
       "version": "13.3.0",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,6 @@
     "lint:styles": "stylelint src/**/*.{css,scss}"
   },
   "dependencies": {
-    "@next/font": "^13.3.1",
     "@types/node": "18.15.11",
     "@types/react": "18.0.37",
     "@types/react-dom": "18.0.11",

--- a/src/pages/_app.tsx
+++ b/src/pages/_app.tsx
@@ -1,7 +1,7 @@
 import "@/styles/main.scss";
 import type { AppProps } from "next/app";
 
-import localFont from "@next/font/local";
+import localFont from "next/font/local";
 
 const netflixSans = localFont({
   src: [


### PR DESCRIPTION
**In this PR**
@next/font migrated to built-in-next-font