### PR TITLE
Feat/borderless email subscription variant

### DIFF
--- a/src/components/EmailSubscription/EmailSubscription.tsx
+++ b/src/components/EmailSubscription/EmailSubscription.tsx
@@ -4,18 +4,26 @@ import Button from "../Button/Button";
 
 type EmailSubscription = {
   className?: string;
+  variant: "bordered" | "plain";
 } & React.ComponentProps<"div">;
 
-const EmailSubscription = ({ className, ...other }: EmailSubscription) => {
+const EmailSubscription = ({
+  className,
+  variant,
+  ...other
+}: EmailSubscription) => {
   const classes = cx(
-    "email-subscription rounded-lg w-full border-4 border-transparent mt-8 p-4",
+    "email-subscription w-full border-transparent",
+    {
+      "rounded-lg p-4 border-4": variant === "bordered",
+    },
     className,
   );
 
   return (
     <div className={classes} {...other}>
       <form className="flex flex-col">
-        <h3 className="email-subscription__title  text-lg lg:text-xl">
+        <h3 className="email-subscription__title text-lg lg:text-xl">
           Ready to watch? Enter your email to create or restart your membership.
         </h3>
         <div className="pt-4 flex flex-col items-start sm:flex-row">

--- a/src/components/Faq/Faq.tsx
+++ b/src/components/Faq/Faq.tsx
@@ -5,6 +5,7 @@ import Accordion from "../Accordion/Accordion";
 import AccordionItem from "../Accordion/AccordionItem";
 
 import { faq } from "../../data/homepage";
+import EmailSubscription from "../EmailSubscription/EmailSubscription";
 
 type Faq = {
   className?: string;
@@ -19,18 +20,22 @@ const Faq = ({ className, ...other }: Faq) => {
   return (
     <Container>
       <div className={classes} {...other}>
-        <h2 className="font-bold text-3xl text-white sm:text-4xl">
-          Frequently Asked Questions
-        </h2>
-        <Accordion>
-          {faq.map((question, i) => {
-            return (
-              <AccordionItem title={question.title} key={i} index={i}>
-                {question.description}
-              </AccordionItem>
-            );
-          })}
-        </Accordion>
+        <div className="flex flex-col">
+          <h2 className="font-bold text-3xl text-white sm:text-4xl">
+            Frequently Asked Questions
+          </h2>
+          <Accordion>
+            {faq.map((question, i) => {
+              return (
+                <AccordionItem title={question.title} key={i} index={i}>
+                  {question.description}
+                </AccordionItem>
+              );
+            })}
+          </Accordion>
+
+          <EmailSubscription variant="plain" className="mt-4" />
+        </div>
       </div>
     </Container>
   );

--- a/src/components/HeroBanner/HeroBanner.tsx
+++ b/src/components/HeroBanner/HeroBanner.tsx
@@ -18,11 +18,11 @@ const HeroBanner = ({ className, ...other }: HeroBanner) => {
           <h1 className="text-4xl font-black text-white mt-4 mb-0 sm:w-9/12 md:text-5xl lg:text-6xl xl:text-7xl 2xl:text-8xl">
             Unlimited movies, TV shows, and more.
           </h1>
-          <p className="text-lg  font-medium	text-white mt-4 xl:text-2xl">
+          <p className="text-lg font-medium	text-white mt-4 xl:text-2xl">
             Watch anywhere. Cancel anytime.
           </p>
 
-          <EmailSubscription />
+          <EmailSubscription variant="bordered" className="mt-8" />
         </div>
       </Container>
     </div>


### PR DESCRIPTION
**In this PR**
- added `plain` and `bordered` variant in `EmailSubscription` component
- used `plain` variant in `Faq` 
- used `bordered` variant in `HeroBanner`