### PR TITLE
Feat/registration password handling

### DIFF
--- a/public/locales/cs/registration.json
+++ b/public/locales/cs/registration.json
@@ -7,6 +7,14 @@
   },
   "title": "Vítejte zpátky! <br/> Registrace k Netflixu je jednoduchá.",
   "description": "Zadejte heslo a můžete se hned začít dívat.",
+  "registration": {
+    "title": "Vytvořte si heslo a zahajte svoje členství",
+    "description": "Už jen jeden krůček a bude hotovo! <br/> I my máme odpor k papírování."
+  },
+  "registrationEmailInput": {
+    "label": "E-mailová adresa",
+    "errorMessage": "Zadejte prosím platnou e-mailovou adresu"
+  },
   "emailLabel": "E-mail",
   "passwordInput": {
     "label": "Zadejte heslo",

--- a/public/locales/en/registration.json
+++ b/public/locales/en/registration.json
@@ -7,6 +7,14 @@
   },
   "title": "Welcome back! <br/> Joining Netflix is easy.",
   "description": "Enter your password and you'll be watching in no time.",
+  "registration": {
+    "title": "Create a password to start",
+    "description": "Just one more step and you're done! <br/> We hate paperwork, too."
+  },
+  "registrationEmailInput": {
+    "label": "Email adress",
+    "errorMessage": "Please enter a valid email address."
+  },
   "emailLabel": "E-mail",
   "passwordInput": {
     "label": "Enter your password",

--- a/src/components/Input/Input.tsx
+++ b/src/components/Input/Input.tsx
@@ -13,6 +13,7 @@ type Input = {
   value?: string;
   errorMessage: string;
   error: boolean;
+  success?: boolean;
   onBlur?: React.FocusEventHandler<HTMLInputElement>;
   onFocus?: React.FocusEventHandler<HTMLInputElement>;
   onChange?: React.FocusEventHandler<HTMLInputElement>;
@@ -29,6 +30,7 @@ const Input = forwardRef((props: Input, ref) => {
     variant = "dark",
     errorMessage,
     error,
+    success,
     value,
     onBlur,
     onFocus,
@@ -57,6 +59,7 @@ const Input = forwardRef((props: Input, ref) => {
     "input__field__input border rounded border-solid pt-6 px-4 pb-2 w-full leading-6",
     {
       "input__field__input--error": error,
+      "input__field__input--success": success,
       [`input__field__input--${variant}`]: variant,
     },
     inputClassName,

--- a/src/components/Input/styles/style.scss
+++ b/src/components/Input/styles/style.scss
@@ -40,6 +40,10 @@
     &--error {
       border-color: $color-primary;
     }
+
+    &--success {
+      border-color: $color-success;
+    }
   }
 
   &__errorMessage {

--- a/src/components/RegistrationEmailForm/RegistrationEmailForm.tsx
+++ b/src/components/RegistrationEmailForm/RegistrationEmailForm.tsx
@@ -19,6 +19,7 @@ const RegistrationEmailForm = ({
   ...other
 }: RegistrationEmailForm) => {
   const [error, setError] = useState<boolean>(false);
+  const [success, setSuccess] = useState<boolean>(false);
   const [inputValue, setInputValue] = useState<string>("");
   const [inputField, setInputField] = useState<HTMLInputElement | null>(null);
 
@@ -90,12 +91,25 @@ const RegistrationEmailForm = ({
       router.push("/signup/password");
 
       dispatch(addEmail(inputValue));
+
+      localStorage.setItem("registration-email", inputValue);
     }
   };
 
   useEffect(() => {
     setInputField(inputRef.current);
-  }, []);
+
+    if (localStorage.getItem("registration-email")) {
+      const localStorageRegistrationEmail =
+        localStorage.getItem("registration-email");
+
+      if (localStorageRegistrationEmail) {
+        setInputValue(localStorageRegistrationEmail);
+        setSuccess(true);
+        dispatch(addEmail(localStorageRegistrationEmail));
+      }
+    }
+  }, [dispatch]);
 
   return (
     <div className={classes} {...other}>
@@ -115,6 +129,8 @@ const RegistrationEmailForm = ({
             error={error}
             autoComplete="off"
             inputContainerClassName="sm:w-auto sm:max-w-sm"
+            value={inputValue}
+            success={success}
           />
 
           <Button

--- a/src/styles/base/colors.scss
+++ b/src/styles/base/colors.scss
@@ -5,3 +5,4 @@ $color-black: #000;
 $color-white: #fff;
 $color-lightgrey: #494949;
 $color-background: #00081d;
+$color-success: #2bb871;


### PR DESCRIPTION
# In this PR
- added data to `locales` for email input field in `registration/password` page
- added `success` prop to `Input`
- added `success` state style for `Input`
- added support for `success` state in `RegistrationEmailForm`
- added new `$color-success` variable

## Password setting refreshing page handling
- Email entered on homepage saved to `redux` state and `localStorage`. After page load there is check if there is some value for `registrationEmail` in `redux` state or `localStorage` and if not, then fully functional input field for email is shown on this page
- Implemented check if there is `registrationEmail` in `redux` state or `localStorage` on homepage. If there is some, then it's auto filled into `RegistrationEmailForm` input and gets `success` state