### PR TITLE
removed localePath attribute from next-i18next config file causing wa…

### DIFF
--- a/next-i18next.config.js
+++ b/next-i18next.config.js
@@ -2,7 +2,6 @@ module.exports = {
   i18n: {
     locales: ["en", "cs"],
     defaultLocale: "en",
-    localePath: "./public/locales",
     localeDetection: false,
   },
 };


### PR DESCRIPTION
# In this PR
- removed `localePath` prop from `next-i18next.config.js` file, which was causing warning in console