### PR TITLE
Fix/movie detail page

### DIFF
--- a/src/components/DashboardBanner/DashboardBanner.tsx
+++ b/src/components/DashboardBanner/DashboardBanner.tsx
@@ -22,6 +22,7 @@ type MovieData = {
   posterPath: string;
   backdropPath: string;
   currentLocale: string;
+  originalName: string;
   releaseDate: string;
   firstAirDate: string;
   lastAirDate: string;
@@ -88,6 +89,7 @@ const DashboardBanner = ({ className, ...other }: DashboardBanner) => {
                 releaseDate: response.data.release_date,
                 firstAirDate: response.data.first_air_date,
                 lastAirDate: response.data.last_air_date,
+                originalName: response.data.original_name,
                 runtime:
                   response.data.runtime || response.data.episode_run_time,
                 tagline: response.data.tagline,
@@ -258,6 +260,7 @@ const DashboardBanner = ({ className, ...other }: DashboardBanner) => {
           onClose={() => {
             setIsModalOpened(false);
           }}
+          originalName={movieData.originalName}
           title={movieData.title}
           genres={movieData.genres}
           releaseDate={movieData.releaseDate}

--- a/src/components/DashboardMovie/DashboardMovie.tsx
+++ b/src/components/DashboardMovie/DashboardMovie.tsx
@@ -26,6 +26,7 @@ type MovieData = {
   tagline: string;
   overview: string;
   originalTitle: string;
+  originalName: string;
   productionCompanies: [{ name: string }];
   productionCountries: [{ name: string }];
   spokenLanguages: [{ name: string }];
@@ -93,6 +94,7 @@ const DashboardMovie = ({
             tagline: response.data.tagline,
             overview: response.data.overview,
             originalTitle: response.data.original_title,
+            originalName: response.data.original_name,
             productionCompanies: response.data.production_companies,
             productionCountries: response.data.production_countries,
             spokenLanguages: response.data.spoken_languages,
@@ -132,6 +134,7 @@ const DashboardMovie = ({
                 tagline: response.data.tagline,
                 overview: response.data.overview,
                 originalTitle: response.data.original_title,
+                originalName: response.data.original_name,
                 productionCompanies: response.data.production_companies,
                 productionCountries: response.data.production_countries,
                 spokenLanguages: response.data.spoken_languages,
@@ -179,6 +182,7 @@ const DashboardMovie = ({
               tagline: response.data.tagline,
               overview: response.data.overview,
               originalTitle: response.data.original_title,
+              originalName: response.data.original_name,
               productionCompanies: response.data.production_companies,
               productionCountries: response.data.production_countries,
               spokenLanguages: response.data.spoken_languages,
@@ -232,6 +236,7 @@ const DashboardMovie = ({
           trigger={popUpTrigger}
           title={title}
           originalTitle={movieData.originalTitle}
+          originalName={movieData.originalName}
           movieId={movieData.id}
           backdropPath={movieData.backdropPath}
           currentLocale={movieData.currentLocale}
@@ -263,6 +268,7 @@ const DashboardMovie = ({
           releaseDate={movieData.releaseDate}
           runtime={movieData.runtime}
           originalTitle={movieData.originalTitle}
+          originalName={movieData.originalName}
           productionCompanies={movieData.productionCompanies}
           productionCountries={movieData.productionCountries}
           spokenLanguages={movieData.spokenLanguages}

--- a/src/components/DashboardMoviePopUp/DashboardMoviePopUp.tsx
+++ b/src/components/DashboardMoviePopUp/DashboardMoviePopUp.tsx
@@ -16,6 +16,7 @@ type DashboardMoviePopUp = {
   trigger: null | HTMLCanvasElement;
   title: string;
   originalTitle: string;
+  originalName: string;
   movieId: number;
   backdropPath: string;
   runtime: number;
@@ -33,6 +34,7 @@ type DashboardMoviePopUp = {
 const DashboardMoviePopUp = ({
   title,
   originalTitle,
+  originalName,
   trigger,
   isOpened = false,
   movieId,
@@ -190,7 +192,7 @@ const DashboardMoviePopUp = ({
               shape="square"
               className="text-black"
               href={`/watch/${movieId}-${handleStringToUrl(
-                originalTitle || title,
+                originalTitle || originalName,
               )}`}
               onClick={(event) => {
                 event.stopPropagation();

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -25,6 +25,7 @@ type Modal = {
   lastAirDate: string;
   runtime: number;
   originalTitle: string;
+  originalName: string;
   productionCompanies: [{ name: string }];
   productionCountries: [{ name: string }];
   spokenLanguages: [{ name: string }];
@@ -47,6 +48,7 @@ const Modal = ({
   lastAirDate,
   runtime,
   originalTitle,
+  originalName,
   productionCompanies,
   productionCountries,
   spokenLanguages,
@@ -197,7 +199,7 @@ const Modal = ({
             variant="secondary"
             size="medium"
             href={`/watch/${movieId}-${handleStringToUrl(
-              originalTitle || title,
+              originalTitle || originalName,
             )}`}
             icon={{ name: "play", size: "small", className: "mr-2" }}
             className="inline-flex mb-4 text-black"

--- a/src/pages/watch/[slug].tsx
+++ b/src/pages/watch/[slug].tsx
@@ -1,13 +1,12 @@
-import { GetStaticPaths, GetStaticProps } from "next";
+import { GetServerSideProps } from "next";
+import { NextSeo } from "next-seo";
 import axios from "axios";
 import { serverSideTranslations } from "next-i18next/serverSideTranslations";
 
 import Layout from "@/components/Layout/Layout";
 import Container from "@/components/Container/Container";
 
-import { requests } from "../../data/categoryRequests";
 import { handleStringToUrl } from "@/utils/utils";
-import { NextSeo } from "next-seo";
 
 type MovieDetail = {
   data: {
@@ -16,13 +15,6 @@ type MovieDetail = {
     id: number;
     overview: string;
   };
-};
-
-type Movie = {
-  id: number;
-  title?: string;
-  name?: string;
-  original_title?: string;
 };
 
 const MovieDetail = ({ data }: MovieDetail) => {
@@ -109,48 +101,11 @@ const MovieDetail = ({ data }: MovieDetail) => {
   );
 };
 
-export const getStaticPaths: GetStaticPaths = async ({ locales }) => {
-  const reqs = Object.keys(requests).map((key: string) =>
-    axios.get(requests[key]),
-  );
+export const getServerSideProps: GetServerSideProps = async (context) => {
+  const { slug } = context.query;
+  const locale = context.locale!;
 
-  //@ts-ignore
-  const responses = await axios.all(reqs);
-
-  const paths = responses
-    .map((response) => {
-      return response.data.results.map((data: Movie) => {
-        const title = data.original_title || data.name || data.title;
-
-        return { params: { slug: `${data.id}-${handleStringToUrl(title!)}` } };
-      });
-    })
-    .flat();
-
-  const localizedPaths = paths.flatMap((path) => {
-    return locales?.map((locale) => {
-      return {
-        ...path,
-        params: {
-          ...path.params,
-        },
-        locale: locale,
-      };
-    });
-  });
-
-  return {
-    paths: localizedPaths,
-    fallback: false,
-  };
-};
-
-export const getStaticProps: GetStaticProps = async ({
-  params,
-  locale,
-}: any) => {
-  const movieId = Number(params.slug.split("-")[0]);
-  const slug = params.slug;
+  const movieId = Number(slug?.toString().split("-")[0]);
 
   try {
     //Checks for movie


### PR DESCRIPTION
# In this PR

### Refactor of getting data in dynamic movie detail pages
- `getStaticPaths` and `getStaticProps` were removed and this functionality is getting done in `getServerSideProps` in `slug` file

### DashboardMovie
- added support for `originalTitle` in `MovieData`
- passed `originalTitle` to `Modal` and `DashboardMoviePopUp`

### DashboardMoviePopUp
- added support for `originalTitle` prop and used it in `href` condition

### Modal
- added support for `originalTitle` prop and used it in `href` condition

### DashboardBanner
- added support for `originalName` prop and passed it to `Modal`