### PR TITLE
Fix/dynamic movie data

### DIFF
--- a/src/components/DashboardBanner/DashboardBanner.tsx
+++ b/src/components/DashboardBanner/DashboardBanner.tsx
@@ -150,7 +150,9 @@ const DashboardBanner = ({ className, locale, ...other }: DashboardBanner) => {
                     size="medium"
                     shape="square"
                     className="text-black mr-4"
-                    href={`/watch/${movieData?.id}-${handleStringToUrl(
+                    href={`/watch/${movieData?.mediaType}-${
+                      movieData?.id
+                    }-${handleStringToUrl(
                       movieData?.originalTitle! || movieData?.title!,
                     )}`}
                     onClick={(event) => {

--- a/src/components/DashboardMovie/DashboardMovie.tsx
+++ b/src/components/DashboardMovie/DashboardMovie.tsx
@@ -108,6 +108,7 @@ const DashboardMovie = ({
           }}
           genres={movieData.genres}
           tagline={movieData.tagline}
+          mediaType={movieData.mediaType}
           runtime={movieData.runtime}
           releaseDate={movieData.releaseDate}
           firstAirDate={movieData.firstAirDate}

--- a/src/components/DashboardMoviePopUp/DashboardMoviePopUp.tsx
+++ b/src/components/DashboardMoviePopUp/DashboardMoviePopUp.tsx
@@ -27,7 +27,6 @@ type DashboardMoviePopUp = {
   | "productionCountries"
   | "spokenLanguages"
   | "videos"
-  | "mediaType"
 >;
 
 const DashboardMoviePopUp = ({
@@ -38,6 +37,7 @@ const DashboardMoviePopUp = ({
   isOpened = false,
   id,
   backdropPath,
+  mediaType,
   locale,
   runtime,
   releaseDate,
@@ -190,7 +190,7 @@ const DashboardMoviePopUp = ({
               size="medium"
               shape="square"
               className="text-black"
-              href={`/watch/${id}-${handleStringToUrl(
+              href={`/watch/${mediaType}-${id}-${handleStringToUrl(
                 originalTitle || originalName,
               )}`}
               onClick={(event) => {

--- a/src/components/Modal/Modal.tsx
+++ b/src/components/Modal/Modal.tsx
@@ -183,7 +183,7 @@ const Modal = ({
           <Button
             variant="secondary"
             size="medium"
-            href={`/watch/${id}-${handleStringToUrl(
+            href={`/watch/${mediaType}-${id}-${handleStringToUrl(
               originalTitle || originalName,
             )}`}
             icon={{ name: "play", size: "small", className: "mr-2" }}


### PR DESCRIPTION
# In this PR

### [slug]
- refactored `getServerSideProps` function to work with `mediaType` which is now in `slug`. Based on this, can easily make the correct api call or redirect to error page using `notFound` 

### DashboardMoviePopUp
- added `mediaType` to `href` (slug)

### DashboardBanner
- added `mediaType` to `href` (slug)

### Modal
- added `mediaType` to `href` (slug)

### DashboardMovie
- added support for `mediaType`